### PR TITLE
Add glib to conda installation

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -98,7 +98,7 @@ will set up an anaconda environment that includes all the dependencies you need
 to use The Workbench. 
 
 ```sh
-conda create -n workbench 'git>=2.28' 'r-base>=3.6' 'pandoc>=2.11' pkg-config libxslt
+conda create -n workbench 'git>=2.28' 'r-base>=3.6' 'pandoc>=2.11' pkg-config libxslt glib
 conda activate workbench
 R -e 'install.packages(c("sandpaper", "varnish", "pegboard", "tinkr"), \
   repos = list(carpentries="https://carpentries.r-universe.dev/", CRAN="https://cloud.r-project.org"))'


### PR DESCRIPTION
During Anaconda installation on macOS, build of `textshaping` fails with:

```output
x86_64-apple-darwin13.4.0-clang++ -std=gnu++17 -dynamiclib -Wl,-headerpad_max_install_names -undefined dynamic_lookup -single_module -multiply_defined suppress -L/Users/guyer/anaconda3/envs/workbench/lib/R/lib -Wl,-dead_strip_dylibs -Wl,-headerpad_max_install_names -Wl,-dead_strip_dylibs -Wl,-rpath,/Users/guyer/anaconda3/envs/workbench/lib -L/Users/guyer/anaconda3/envs/workbench/lib -o textshaping.so cpp11.o face_feature.o hb_shaper.o init.o string_bidi.o string_metrics.o string_shape.o -L/Users/guyer/anaconda3/envs/workbench/lib -lharfbuzz -lm -framework ApplicationServices -lglib-2.0 -lintl -liconv -lm -framework Foundation -framework CoreFoundation -framework AppKit -framework Carbon -lpcre2-8 -lgraphite2 -lfreetype -lz -lpng16 -lz -lfribidi -L/Users/guyer/anaconda3/envs/workbench/lib/R/lib -lR -Wl,-framework -Wl,CoreFoundation
ld: library not found for -lglib-2.0
x86_64-apple-darwin13.4: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [/Users/guyer/anaconda3/envs/workbench/lib/R/share/make/shlib.mk:10: textshaping.so] Error 1
ERROR: compilation failed for package ‘textshaping’
```

