### PR TITLE
style: Apply Style Guide for 'Workbench'

### DIFF
--- a/.github/workflows/build-quarto.yaml
+++ b/.github/workflows/build-quarto.yaml
@@ -14,7 +14,7 @@ permissions:
   contents: write
   deployments: write
   actions: write
-  
+
 jobs:
   build-deploy:
     runs-on: ubuntu-22.04
@@ -58,6 +58,7 @@ jobs:
             any::sessioninfo
 
       - name: Deploy 🚀
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
         uses: quarto-dev/quarto-actions/publish@v2
         with:
           target: gh-pages

--- a/beta-phase.qmd
+++ b/beta-phase.qmd
@@ -13,7 +13,7 @@ Carpentries Lessons as a whole. Of course, with over 100 maintainers and even
 more instructors, making a sudden change has the potential to be massively
 disruptive.
 
-Instead, we are slowly releasing The Workbench in **three stages**
+Instead, we are slowly releasing the Workbench in **three stages**
 over a **16 week period during which there will be _parallel websites_ showing
 two versions of the same lesson[^parallel-nightmares].** For example, when you
 visit `https://datacarpentry.org/R-ecology-lesson`, there will be a banner at
@@ -31,8 +31,8 @@ The three stages are called ["pre-beta"](#pre-beta), ["beta"](#beta)[^beta], and
 
 If you would like to participate in the beta phase, you can
 
- - [find out more about our workbench through our Resource Guide](index.html#resources),
- - **[introduce yourself](https://github.com/carpentries/workbench/discussions/1)**, and 
+ - [find out more about our Workbench through our Resource Guide](index.html#resources),
+ - **[introduce yourself](https://github.com/carpentries/Workbench/discussions/1)**, and
  - [give feedback via GitHub Discussions](https://github.com/carpentries/workbench/discussions/)
 
 
@@ -62,7 +62,7 @@ new lesson page with a timeframe of 6 months"}
 
 ### **pre-beta** (two repos, two sites) {#pre-beta}
 
-Lessons in this stage will have a workbench version of the lesson live in a
+Lessons in this stage will have a Workbench version of the lesson live in a
 separate repository in a [sandbox GitHub
 organisation](https://github.com/fishtree-attempt)[^pun]. This version will be a
 **snapshot from the date of the pre-beta version**. Any changes made to the
@@ -118,7 +118,7 @@ a change.
 :::
 :::::
 
-### **beta** (one repo using the workbench, two sites) {#beta}
+### **beta** (one repo using the Workbench, two sites) {#beta}
 
 
 Lessons in this stage will undergo a lesson release of the styles version and a
@@ -134,7 +134,7 @@ transformation[^modify] of the default branch will be inserted as `main`:
 
 The default lesson URL will still be served from the `legacy/gh-pages` branch
 during this period. **All new changes to the lesson will be made to the
-workbench version.**
+Workbench version.**
 
 ::::: {#beta-tasks .callout-note}
 
@@ -247,13 +247,13 @@ git remote set-head origin -a      # set main branch to be your local default
   [swcarpentr/bc](https://github.com/swcarpentry/bc) monorepo, they excised the
   commits related to each lesson from the repository, but preserved the history.
 
-Maintainers will continue to work on this workbench version of the lesson.
+Maintainers will continue to work on this Workbench version of the lesson.
 
-### **pre-release (release-candidate)** (one repo using workbench, one site) {#pre-release}
+### **pre-release (release-candidate)** (one repo using Workbench, one site) {#pre-release}
 
 The styles version of the lesson (in the `legacy/` branches) will be removed,
-the default version of the lesson will switch to The Workbench, and the 
-workbench-beta website will redirect to the live lesson.
+the default version of the lesson will switch to the Workbench, and the 
+Workbench-beta website will redirect to the live lesson.
 
 ## Lessons currently in the beta phase
 

--- a/contributor/beta-url.html
+++ b/contributor/beta-url.html
@@ -50,7 +50,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 default:
                     // default to the repository
                     newpath = newpath.slice(0, 3);
-                    explainer = "<strong>We could not determine the path to this file in The Workbench</strong><br>";
+                    explainer = "<strong>We could not determine the path to this file in the Workbench</strong><br>";
                     console.log(newpath);
                     break;
             }

--- a/contributor/beta.qmd
+++ b/contributor/beta.qmd
@@ -14,7 +14,7 @@ of a lesson that is being tested in \
 The Workbench Beta Phase 
 
 ::: {style='text-align: left;'}
- - any edits you propose will be made on **The Workbench version of the lesson.**
+ - any edits you propose will be made on **the Workbench version of the lesson.**
  - [Find out more about the **beta stage**](../beta-phase.html#beta).
 
 :::

--- a/contributor/index.qmd
+++ b/contributor/index.qmd
@@ -172,7 +172,7 @@ flowchart TB
 
 ## Development
 
-Development of The Workbench is overseen by Zhian N. Kamvar. New features are
+Development of the Workbench is overseen by Zhian N. Kamvar. New features are
 added incrementally as pull requests. Pushes to the main branch are _rare_ and
 discouraged. New features must have tests associated (with the exception of
 {varnish}).
@@ -206,7 +206,7 @@ writeLines(system2(c("git", "--version"), stdout = TRUE))
 
 
 Once you have these installed, make sure to install ALL of the dependencies for
-the workbench:
+the Workbench:
 
 ```{.r}
 install.packages(c("sandpaper", "pegboard", "varnish", "tinkr"),

--- a/contributor/releases.qmd
+++ b/contributor/releases.qmd
@@ -4,7 +4,7 @@ title: "Release Process for Workbench Packages"
 
 ## Background
 
-The workbench contains three main packages:
+The Workbench contains three main packages:
 
  - [{sandpaper}]\: user interface and workflow engine
  - [{pegboard}]\: parsing and validation engine
@@ -12,7 +12,7 @@ The workbench contains three main packages:
 
 Each of these packages are available on the [Carpentries R-Universe][r-universe]
 and new versions are checked for hourly. This allows folks to get up-to-date
-versions of The Workbench packages built for their system without running out
+versions of the Workbench packages built for their system without running out
 of GitHub API query attempts.
 
 In order to maintain quality, packages are only sent to the R-Universe if they

--- a/contributor/sandpaper.qmd
+++ b/contributor/sandpaper.qmd
@@ -5,7 +5,7 @@ subtitle: "The User Interface and Engine"
 
 ## Introduction
 
-The user interface to [The Workbench](../reference.html#workbench) is an R
+The user interface to [the Workbench](../reference.html#workbench) is an R
 package called [{sandpaper}](../reference.html#sandpaper). This package is
 responsible for the following broad areas.
 

--- a/contributor/testing.qmd
+++ b/contributor/testing.qmd
@@ -30,11 +30,11 @@ lesson authors and maintainers as much freedom as they need to write a lesson
 while maintaining predictability and integrity. We also want to give our
 community confidence that this system works. 
 
-Whenever a new feature or bug fix is added to The Workbench, it is imperative
+Whenever a new feature or bug fix is added to the Workbench, it is imperative
 that a test is associated and verified before it gets sent into production.
 
 Tests can be run locally and via continuous integration. This page introduces
-some of the testing strategies used in The Workbench and the caveats that come
+some of the testing strategies used in the Workbench and the caveats that come
 with these strategies.
 
 ## Unit Testing

--- a/docker/README.md
+++ b/docker/README.md
@@ -2,7 +2,7 @@
 
 This is a WIP dockerfile for running The Carpentries Workbench. The installed
 size is just over 4GB. Note, building this container once will give you a
-snapshot of the workbench _at a particular time_. Given the fact that The
+snapshot of the Workbench _at a particular time_. Given the fact that The
 Workbench is continuously improving, you may want to consider rebuilding the
 container periodically.
 

--- a/faq.qmd
+++ b/faq.qmd
@@ -21,7 +21,7 @@ If you have a question about definitions, consult our [glossary](reference.html#
 ## Authoring
 
 These FAQs are intended for those who contribute to, maintain, or create lessons
-using The Workbench. If you only ever visit the website, then head over to 
+using the Workbench. If you only ever visit the website, then head over to 
 the [Teaching](#teaching) or [Learning](#learning) sections.
 
 ### Why was R chosen for the infrastructure? {#why-r}
@@ -48,7 +48,7 @@ We tested the infrastructure in 2021 to make sure that it works for people with
 varying levels of familiarity with R:
 See this [Blog Post from 2021 on the Alpha Test of the infrastructure](https://carpentries.org/blog/2021/07/infrastructure-testing/).
 
-Zhian Kamvar has given two talks about The Workbench that go into a little bit
+Zhian Kamvar has given two talks about the Workbench that go into a little bit
 more detail about why we chose R (which highlight the points above)
 
 | Talk | Video | Slides (with speaker notes) |
@@ -109,7 +109,7 @@ These branches are part of [the remote two-step workflow](https://carpentries.gi
    comparison of rendered output in Pull Requests
  - `gh-pages`: contains the rendered website.
 
-### Why is The Workbench creating so many `md-outputs-PR` branches?
+### Why is the Workbench creating so many `md-outputs-PR` branches?
 
 You might notice that every time a valid pull request is opened, a new branch
 is created. Each branch is unique to a pull request and is automatically removed
@@ -122,7 +122,7 @@ pull request. The diff between these commits can be used to analyse changes in
 output of R Markdown documents. For more information, please read the [Auditing
 Pull Requests
 Chapter](https://carpentries.github.io/sandpaper-docs/pull-request.html) in the
-Introduction to The Workbench.
+Introduction to the Workbench.
 
 ### How do I add a custom logo?
 
@@ -154,9 +154,9 @@ some around and created a few iterations as discussed in
 
 This section is applicable for transitioning between the former
 [carpentries/styles](https://github.com/carpentries/styles) lesson
-infrastructure and The Workbench.
+infrastructure and the Workbench.
 
-### How do I transition my lesson to using The Workbench? {#transition-new}
+### How do I transition my lesson to using the Workbench? {#transition-new}
 
 ::: {.callout-warning}
 
@@ -185,7 +185,7 @@ lesson.
  - [Transitioning and uploading a lesson](https://github.com/carpentries/lesson-transition/blob/main/release-workflow.md)
 
 
-### How do I transition a long-running fork to using The Workbench? {#long-fork}
+### How do I transition a long-running fork to using the Workbench? {#long-fork}
 
 See [the above section](#transition-new) for instructions. You can copy the
 lesson-specific transition script to your fork folder to make things easier
@@ -318,7 +318,7 @@ Note that if you have a clone, you will need to also [delete and re-clone](#upda
 ##### Production Forks
 
 If you have a fork of a lesson that you have modified significantly and wish to
-continue maintaining under The Workbench, contact Zhian Kamvar and he will help
+continue maintaining under the Workbench, contact Zhian Kamvar and he will help
 you transition your repository. 
 
 :::
@@ -345,7 +345,7 @@ accidentally merge histories in your fork.
 #### How do I create a fork for teaching? {#teaching-fork}
 
 A common pattern for teaching is to create a fork of a lesson, modify it to add
-or remove specific section. Because the pages on The Workbench are deployed by
+or remove specific section. Because the pages on the Workbench are deployed by
 GitHub actions, there are a couple of extra steps you need to do to enable the 
 pages to load after the transition.
 
@@ -382,10 +382,10 @@ sure that the content is stable.
 The website <https://htmlpreview.github.io> allows you to display HTML pages
 hosted on GitHub without needing to set up GitHub pages. If you do not want to
 fork, but still want a working version you can teach from, you can head to a 
-workbench repository, select the `gh-pages` branch, select the `index.html` file
+Workbench repository, select the `gh-pages` branch, select the `index.html` file
 and click on `copy permalink` and paste that into html preview:
 
-For example: this is the workbench documentation as of 2023-02-07: 
+For example: this is the Workbench documentation as of 2023-02-07:
 <https://htmlpreview.github.io/?https://github.com/carpentries/sandpaper-docs/blob/59651a69e7716c04edaf8f9c1c79abc18ce3e476/index.html>
 
 This is a very workable version of the lesson (with some styling differences as

--- a/index.qmd
+++ b/index.qmd
@@ -88,8 +88,8 @@ accessibility tests, and more, consult our [Guides](#guides)
 
 #### Within R
 
-To install the workbench, make sure you have a working version of R and
-pandoc/RStudio installed (see [the workbench setup instructions for
+To install the Workbench, make sure you have a working version of R and
+pandoc/RStudio installed (see [the Workbench setup instructions for
 details](https://carpentries.github.io/sandpaper-docs/)).
 
 From there, you can install the Workbench packages and their dependencies from
@@ -156,7 +156,7 @@ conda activate workbench
 
 ### Updating
 
-To update workbench packages, you can use:
+To update Workbench packages, you can use:
 
 ::: {.panel-tabset}
 
@@ -190,7 +190,7 @@ conda update --name workbench r-tinkr r-varnish r-pegboard r-sandpaper
 
 ### Tools
 
- - [{sandpaper}]\: User interface and engine for the workbench
+ - [{sandpaper}]\: User interface and engine for the Workbench
  - [{pegboard}]\: Validation and parsing of lesson components
  - [{varnish}]\: HTML, CSS, and JavaScript templates
  - [(carpentries/actions)](https://github.com/carpentries/actions#readme): GitHub Actions for Workbench Workflows
@@ -214,6 +214,6 @@ These are examples of lessons developed with the Workbench since the initial ann
 
 
 
-[{sandpaper}]: https://carpentries.github.io/sandpaper/ "User interface and engine for the workbench"
+[{sandpaper}]: https://carpentries.github.io/sandpaper/ "User interface and engine for the Workbench"
 [{pegboard}]: https://carpentries.github.io/pegboard/ "Validation and parsing of lesson components"
 [{varnish}]: https://carpentries.github.io/varnish/ "HTML, CSS, and JavaScript templates"

--- a/reference.qmd
+++ b/reference.qmd
@@ -13,11 +13,11 @@ Below are terms used in association with The Carpentries Workbench.
 
 [lesson source]{#lesson-source .anchored}
 : a collection of standard files and folders generated from a [lesson
-  template])#template) that [The Workbench](#workbench) uses to build a lesson
+  template])#template) that [the Workbench](#workbench) uses to build a lesson
   website
 
 [lesson website]{#lesson-website .anchored}
-: An HTML website built by [The Workbench](#workbench).
+: An HTML website built by [the Workbench](#workbench).
 
 [{sandpaper}](https://carpentries.github.io/sandpaper){#sandpaper .anchored}
 : the package that lesson contributors interact with. This orchestrates the
@@ -39,11 +39,11 @@ Below are terms used in association with The Carpentries Workbench.
 
 [Markdown Lesson Template]{#markdown-lesson-template .anchored}
 : <https://bit.ly/new-lesson-md> a GitHub repository template to create a new
-  lesson written in markdown using The Workbench
+  lesson written in markdown using the Workbench
 
 [R Markdown Lesson Template]{#r-markdown-lesson-template .anchored}
 : <https://bit.ly/new-lesson-rmd> a GitHub repository template to create a new
-  lesson written in R Markdown using The Workbench
+  lesson written in R Markdown using the Workbench
 
 [Official Lessons]{#official-lessons .anchored}
 : Lessons within our Official Curriculum that are offered in
@@ -97,14 +97,14 @@ Below are terms used in association with The Carpentries Workbench.
   for each lesson.
 
 [Pre-beta stage (8 weeks)](beta-phase.html#pre-beta){#pre-beta-stage .anchored}
-: a snapshot of a lesson is converted to the workbench in a separate github
+: a snapshot of a lesson is converted to the Workbench in a separate github
   organisation and hosted on a temporary url
   (`preview.carpentries.org/<lesson>`). A banner is hosted on the github URL
   indicating a beta test with a link to the new url. 
 
 [Beta stage (8 weeks)](beta-phase.html#beta){#beta-stage .anchored}
 : a lesson release and archive is created. The lesson is converted to the
-  workbench and hosted on (preview.carpentries.org/<lesson>). The github URL
+  Workbench and hosted on (preview.carpentries.org/<lesson>). The github URL
   hosts the snapshot of the lesson at the given release and has a link to the
   new URL, indicating that it is the up-to-date version.
 

--- a/transition-guide.qmd
+++ b/transition-guide.qmd
@@ -11,7 +11,7 @@ The Carpentries Workbench is a replacement for the former [carpentries/styles]
 lesson infrastructure. Lessons using The Carpentries Workbench have content
 separated from styling and build tools for a more seamless experience in updates
 to the lesson websites. In 2023, all lessons in official Carpentries lesson
-programs were converted to use The Workbench using the
+programs were converted to use the Workbench using the
 [lesson-transition tool](https://github.com/carpentries/lesson-transition#readme).
 We provide [a documented transition workflow](https://carpentries.github.io/sandpaper-docs/migrating-from-styles.html) 
 for lesson developers to follow if they want to convert their own lessons.
@@ -20,7 +20,7 @@ for lesson developers to follow if they want to convert their own lessons.
 
 This document is intended to provide you with a quick reference about the
 differences between [kramdown] (used by styles) and [pandoc-flavoured
-markdown][pandoc] (used by The Workbench):
+markdown][pandoc] (used by the Workbench):
 
 
 ## For Maintainers
@@ -53,7 +53,7 @@ then the default branch is `main`
 
 #### Workbench
 
-The workbench infrastructure is **independent**^[one exception: github
+The Workbench infrastructure is **independent**^[one exception: github
 workflows are contained inside the `.github/workflows` folder] from individual
 lessons. It consists of three major pieces of software.
 
@@ -61,7 +61,7 @@ lessons. It consists of three major pieces of software.
  - **R**
  - **[Pandoc][pandoc]**
 
-The workbench itself consists of three R packages, which can all be updated on
+The Workbench itself consists of three R packages, which can all be updated on
 the fly with no changes to the lesson.
 
  - [{sandpaper}]\: user interface and workflow engine
@@ -142,7 +142,7 @@ on the underlying infrastructure, going back to 2013.
 
 #### Workbench
 
-1. If you haven't already, Follow the [setup instructions for the workbench][workbench-setup] to install R, pandoc, and the workbench packages
+1. If you haven't already, Follow the [setup instructions for the Workbench][workbench-setup] to install R, pandoc, and the Workbench packages
 2. In your lesson directory, open either [R](https://cloud.r-project.org/), [RStudio](https://www.rstudio.com/products/rstudio/download/#download), or [VS Code](https://code.visualstudio.com/docs/languages/r) and run:
 
 ```r
@@ -182,7 +182,7 @@ single folder `episodes/`. `_extras/` content will be split into `learners/`
 and `instructors/` depending on the context of the content. Figures, data, and
 files all become subfolders of `episodes/`.
 ![](fig/folder-flow.svg){data-alt='A diagram showing the transition between the
-former lesson structure (styles) to the new lesson structure (workbench). It
+former lesson structure (styles) to the new lesson structure (Workbench). It
 shows episodes flowing to episodes, extras flowing to learners and instructors,
 and figures, data, and files flowing to subfolders under episodes. Other
 folders are in grey with no arrows indicating that they are discarded.'}
@@ -236,12 +236,12 @@ On the rendred site, the setup instructions are in a separate page called `/setu
 
 #### Workbench
 
-A callout block with The Workbench uses _at least_ three colons followed by a
+A callout block with the Workbench uses _at least_ three colons followed by a
 keyword to start a block. The block is closed with _at least_ three colons.
 
 ::::: {.callout-note}
 
-You can find a demonstration of all the possible callout blocks in [the workbench component guide](https://carpentries.github.io/sandpaper-docs/component-guide.html)
+You can find a demonstration of all the possible callout blocks in [the Workbench component guide](https://carpentries.github.io/sandpaper-docs/component-guide.html)
 
 :::::
 
@@ -310,7 +310,7 @@ document.
 
 #### Workbench
 
-Code fences in the workbench are indicated by fences that consist of three
+Code fences in the Workbench are indicated by fences that consist of three
 backticks (```` ``` ````) with the name of the language appended on the opening 
 fence:
 <br>
@@ -354,7 +354,7 @@ git branch --merged | grep -v '^\*' | xargs git branch -d
 
 #### Workbench
 
-The challenge and solution blocks in the workbench are nested pairs of blocks
+The challenge and solution blocks in the Workbench are nested pairs of blocks
 with an optional Level 3 header. You can additonally add a "hint" block before
 the solution.
 
@@ -395,7 +395,7 @@ compared to the inner section.
 
 #### styles
 
-The challenge and solution blocks in the workbench are nested block quotes
+The challenge and solution blocks in the Workbench are nested block quotes
 with Level 2 headers. Additional blocks are still of the class "solution" 
 
 ````markdown
@@ -523,7 +523,7 @@ use Jekyll's metadata parsing to create a custom introductory block.
 
 #### Workbench
 
-An **inline instructor note** in the workbench is formed inside an episode by
+An **inline instructor note** in the Workbench is formed inside an episode by
 making a [_fenced div_][fenced-divs] with the class "instructor"
 
 ```markdown
@@ -678,7 +678,7 @@ text after the list
 #### About Table Styling
 
 Please note that the table display here is not a good representation of what
-you will see in The Workbench or in Styles. They both have their own 
+you will see in the Workbench or in Styles. They both have their own 
 idiosyncratic ways of displaying tables. 
 
 A demonstration of Workbench tables can be seen [in the official documentation
@@ -692,7 +692,7 @@ for lesson contributors](https://carpentries.github.io/sandpaper-docs/episodes.h
 
 #### Workbench
 
-Tables in the workbench follow the rules for [pandoc pipe table syntax](https://pandoc.org/MANUAL.html#extension-pipe_tables).
+Tables in the Workbench follow the rules for [pandoc pipe table syntax](https://pandoc.org/MANUAL.html#extension-pipe_tables).
 
 There are two extra features for this syntax in pandoc:
 
@@ -911,7 +911,7 @@ The dragon emerges!
 #### Workbench
 
 Episode and setup information is located on the left hand side of the page.
-Navigation in the workbench is split between information for learners and
+Navigation in the Workbench is split between information for learners and
 information for instructors. The top right of the page has a toggle button
 between Learner and Instructor views, which change the four main navigation
 items in the top navigation bar. 
@@ -924,7 +924,7 @@ Key Points, Glossary, Learner Profiles, and More. The "More" dropdown menu
 contains information for learners from the `learners/` folder aside from the
 setup instructions.
 
-![](fig/screenshot-learner-view.png){alt='screenshot of the workbench version
+![](fig/screenshot-learner-view.png){alt='screenshot of the Workbench version
 of "The Unix Shell". A blue arrow points to the top right corner indicating the
 lesson is in "Learner View". The menu bar states the name of the lesson and has
 the items described in text, with all but the first underlined. There is a grey
@@ -942,7 +942,7 @@ In addition, the schedule now appears on the home page, instructor notes are
 displayed inline, and the estimated timings for a lesson appear.
 
 
-![](fig/screenshot-instructor-view.png){alt='screenshot of the workbench
+![](fig/screenshot-instructor-view.png){alt='screenshot of the Workbench
 version of "The Unix Shell". A red arrow points to the top right corner
 indicating the lesson is in "Learner View". The menu bar states the name of the
 lesson and has the items described in text, with all but the first underlined
@@ -999,7 +999,7 @@ Learner View) or the "Summary and Schedule" links (in Instructor View) in the
 side navigation bar:
 
 ![](fig/setup-workbench.png){alt='zoomed in screenshot of side navigation of
-a workbench episode showing "Summary and Setup" highlighted'}
+a Workbench episode showing "Summary and Setup" highlighted'}
 
 :::
 
@@ -1033,11 +1033,11 @@ of episodes.
 
 The "Edit This Page" button is located under the heading for each episode:
 
-![](fig/edit-page-head-workbench.png){alt='screenshot of workbench page header that says "Introduction to R" with a highlighted link that says "Edit this page"'}
+![](fig/edit-page-head-workbench.png){alt='screenshot of Workbench page header that says "Introduction to R" with a highlighted link that says "Edit this page"'}
 
 and on the first column of the footer:
 
-![](fig/edit-page-foot-workbench.png){alt='screenshot of workbench page footer that shows the "Edit on GitHub" link highlighted'}
+![](fig/edit-page-foot-workbench.png){alt='screenshot of Workbench page footer that shows the "Edit on GitHub" link highlighted'}
 
 
 
@@ -1075,7 +1075,7 @@ and reuse.
 The License information can be found at the `LICENSE.html` page, whose link is
 always in the footer:
 
-![](fig/license-workbench.png){alt='screenshot of workbench footer with "CC-BY 4.0" license highlighted'}
+![](fig/license-workbench.png){alt='screenshot of Workbench footer with "CC-BY 4.0" license highlighted'}
 
 :::
 
@@ -1110,7 +1110,7 @@ reporting guidelines.
 The Code of Conduct information can be found at the `CODE_OF_CONDUCT.html` page, whose link is
 always in the footer:
 
-![](fig/coc-workbench.png){alt='screenshot of workbench footer with "Code of Conduct" highlighted'}
+![](fig/coc-workbench.png){alt='screenshot of Workbench footer with "Code of Conduct" highlighted'}
 
 :::
 

--- a/transition-schedule.qmd
+++ b/transition-schedule.qmd
@@ -3,7 +3,7 @@ title: "Workbench Transition Schedule"
 ---
 
 Below you will find tables that indicate when a given lesson is expected to
-transition to The Workbench along with a link to the preview and a GitHub issue
+transition to the Workbench along with a link to the preview and a GitHub issue
 tracking progress on the conversion. 
 
 ::: {.callout-note collapse="true"}

--- a/workflow-guide.qmd
+++ b/workflow-guide.qmd
@@ -15,7 +15,7 @@ designed with the following guiding principles:
 3. The procedures should be **well-documented and generalizable** enough that the
    toolchain is not entirely dependent on R.
 
-This document provides details of how the packages of the workbench work
+This document provides details of how the packages of the Workbench work
 behind the scenes to create a full Carpentries lesson website from markdown
 source file. 
 
@@ -28,16 +28,16 @@ which are available via [RStudio](https://rstudio.com)
  - **R**
  - **[Pandoc](https://pandoc.org)**
 
-The workbench itself consists of three R packages, which can all be updated on
+The Workbench itself consists of three R packages, which can all be updated on
 the fly with no changes to the lesson.
 
-There are three packages that comprise The Workbench:
+There are three packages that comprise the Workbench:
 
-- [{sandpaper}](https://carpentries.github.io/sandpaper/): User interface and engine for the workbench
+- [{sandpaper}](https://carpentries.github.io/sandpaper/): User interface and engine for the Workbench
 - [{pegboard}](https://carpentries.github.io/pegboard/): Validation and parsing of lesson components
 - [{varnish}](https://carpentries.github.io/varnish/): HTML, CSS, and JavaScript templates
 
-In addition, The workbench uses the following packages for support:
+In addition, the Workbench uses the following packages for support:
 
 - [{knitr}](https://yihui.org/knitr/): engine that renders R Markdown documents to Markdown
 - [{tinkr}](https://docs.ropensci.org/tinkr/): converts Markdown to an XML representation for {pegboard} to parse
@@ -99,7 +99,7 @@ explain the error and offer correction.
 Because of the need for bootstrapping, validation, and caching, the number of 
 steps from source files to lesson website is considerably more than two. The
 diagram below describes shows the process by which a lesson is built using the
-workbench.
+Workbench.
 
 1. The lesson contributor has an idea and writes it in Markdown or R Markdown
 2. The lesson contributor runs `sandpaper::serve()` to start the engine.


### PR DESCRIPTION
* Ensure all relevant instances of 'Workbench' are capitalised.
* Ensure all instances of 'the Workbench' have a lowercase 'the', unless starting a sentence or in a title that is all caps.
   - c.f. https://docs.carpentries.org/resources/communications/style-guide.html#w

---

* c.f. https://github.com/carpentries/docs.carpentries.org/pull/347
* Follow up to PR https://github.com/carpentries/workbench/pull/90